### PR TITLE
Use HTTPS instead of SSH for GitHub repositories

### DIFF
--- a/bin/plpsdk
+++ b/bin/plpsdk
@@ -91,7 +91,7 @@ def src():
     raise Exception("The target configuration must be specified through option --config")
 
   if not os.path.exists(sdk_src_path):
-    if os.system('git clone git@github.com:pulp-platform/pulp-sdk.git'):
+    if os.system('git clone https://github.com/pulp-platform/pulp-sdk.git'):
       return -1
     os.chdir(sdk_src_path)
   else:


### PR DESCRIPTION
HTTPS supports anonymous cloning, whereas SSH does not.

See https://github.com/pulp-platform/pulp-sdk/pull/11 for arguments and discussion.